### PR TITLE
Fix for [ch54055], add dynamic user_profiles list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLUGIN_VERSION=1.0.1
+PLUGIN_VERSION=1.0.2
 PLUGIN_ID=azure-ad-sync
 
 plugin:

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "azure-ad-sync",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "meta": {
         "label": "Azure Active Directory Sync",
         "description": "Syncing DSS users with AAD groups",

--- a/python-lib/azure_client.py
+++ b/python-lib/azure_client.py
@@ -22,9 +22,6 @@ class AzureClient(object):
     graph_group_url = "https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '{}'&$select=id"
     graph_members_url = "https://graph.microsoft.com/v1.0/groups/{}/members?$select=displayName,userPrincipalName"
 
-    # dss_profile types. These should be ordered from most to least potent.
-    possible_dss_profiles = []
-
     # Define a translation dict that specifies how each credential should
     # be named in the user's secrets
     credentials_labels = {

--- a/python-lib/azure_client.py
+++ b/python-lib/azure_client.py
@@ -23,7 +23,7 @@ class AzureClient(object):
     graph_members_url = "https://graph.microsoft.com/v1.0/groups/{}/members?$select=displayName,userPrincipalName"
 
     # dss_profile types. These should be ordered from most to least potent.
-    possible_dss_profiles = ["DATA_SCIENTIST", "DATA_ANALYST", "READER", "EXPLORER", "NONE"]
+    possible_dss_profiles = []
 
     # Define a translation dict that specifies how each credential should
     # be named in the user's secrets
@@ -52,6 +52,7 @@ class AzureClient(object):
 
         self.client = dataiku.api_client()
         self.run_user = self.client.get_auth_info()["authIdentifier"]
+        self.possible_dss_profiles = self.get_possible_dss_profiles()
         self.session = requests.Session()
 
         # Initialize a dataframe that will contain log data
@@ -98,6 +99,12 @@ class AzureClient(object):
                 return dss_profile_type
         # If no match was found above, default to no dss_profile
         return "NONE"
+
+    def get_possible_dss_profiles(self):
+        licensing = self.client.get_licensing_status()
+        user_profiles = licensing.get('base', []).get('userProfiles', [])
+        user_profiles.append("NONE")
+        return user_profiles
 
     @staticmethod
     def get_required_credentials(auth_method):


### PR DESCRIPTION
Possible issue with this fix:
- Users belong to a number of AAD groups to start with
- Each AAD group as a DSS profile assign to it by provided dataset
- The macro as to make a choice of profile for a given user. Up to now, it was relying on a array of profiles ordered in decreasing potency, but now this list is downloaded from DSS, and there no notion of order
-> a user belonging to several groups might not end up with the highest profile.

Possible fixes:
- Provide us with an exhaustive ranked list of DSS profiles, to be updated when necessary
- Recommend assigning only one DSS related AAD group per user in the doc
