### PR TITLE
Replace dash with underscore

### DIFF
--- a/python-lib/azure_client.py
+++ b/python-lib/azure_client.py
@@ -76,7 +76,7 @@ class AzureClient(object):
 
         :param email: the email address
         """
-        return email.replace("@", "_").replace("#", "_")
+        return email.replace("@", "_").replace("#", "_").replace("-", "_")
 
     @staticmethod
     def list_diff(list1, list2):


### PR DESCRIPTION
We find that dashes in account names cause issues with Linux and would like to replace them with underscores.